### PR TITLE
Reduce error in resistance computation

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "ad5243",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "Arduino library to control the AD5243 family of digital potentiometers / rheostats",
     "keywords": [
         "io"

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ad5243
-version=0.2.0
+version=0.2.1
 author=Dirk O. Kaar
 maintainer=Dirk O. Kaar <dok@dok-net.net>
 sentence= Arduino library to control the AD5243 family of digital potentiometers / rheostats

--- a/src/ad5243.cpp
+++ b/src/ad5243.cpp
@@ -18,7 +18,8 @@
  * SOFTWARE.
  *
  * Datasheet: https://www.analog.com/en/products/ad5243.html
- * Resistance set is measured between B1 and W1 for channel 0, and B2 and W2 for channel 1
+ * Resistance set is measured between B1 and W1 for channel 0, and B2 and W2
+ * for channel 1
  */
 
 #include "ad5243.h"
@@ -40,7 +41,7 @@ bool AD5243::connected()
 
 long AD5243::computedResistance(const uint8_t data)
 {
-	return (data * _nominal_resistance) / 256 + 2 * _wiper_resistance;
+	return (data * _nominal_resistance + 128) / 256 + 2 * _wiper_resistance;
 }
 
 bool AD5243::setData(uint8_t channel, uint8_t data)
@@ -72,7 +73,10 @@ bool AD5243::setData(uint8_t channel, uint8_t data)
 
 bool AD5243::setResistance(uint8_t channel, const long resistance)
 {
-	const uint8_t data = resistance - 2 * _wiper_resistance > 0 ? (resistance - 2 * _wiper_resistance) * 256 / _nominal_resistance : 0;
+	const uint8_t data = resistance - 2 * _wiper_resistance > 0 ?
+		((resistance - 2 * _wiper_resistance) * 256 + _nominal_resistance / 2)
+			/ _nominal_resistance :
+		0;
 	return setData(channel, data);
 }
 


### PR DESCRIPTION
Short of doing float arithmetic, use rounding to nearest integer.
For the 2K5 variant of the chip, steps are 2500/256 = 9.765625 ohm.
