### PR TITLE
Fix spelling error in API

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "ad5243",
-    "version": "0.2.1",
+    "version": "0.3.0",
     "description": "Arduino library to control the AD5243 family of digital potentiometers / rheostats",
     "keywords": [
         "io"

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ad5243
-version=0.2.1
+version=0.3.0
 author=Dirk O. Kaar
 maintainer=Dirk O. Kaar <dok@dok-net.net>
 sentence= Arduino library to control the AD5243 family of digital potentiometers / rheostats


### PR DESCRIPTION
Fixes the `getChannel*Data` spelling mistake recently discovered and corrected in release 0.3.0.