### PR TITLE
Make I2C device address selection optional part of ctor arguments.

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "ad5243",
-    "version": "0.3.1",
+    "version": "0.4.0",
     "description": "Arduino library to control the AD5243 family of digital potentiometers / rheostats",
     "keywords": [
         "io"

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ad5243
-version=0.3.1
+version=0.4.0
 author=Dirk O. Kaar
 maintainer=Dirk O. Kaar <dok@dok-net.net>
 sentence= Arduino library to control the AD5243 family of digital potentiometers / rheostats

--- a/src/ad5243.h
+++ b/src/ad5243.h
@@ -40,15 +40,28 @@ private:
 	uint8_t channel2Data = 0x80;
 
 public:
-	AD5243(long nominal_resistance, TwoWire& i2cPort = Wire) : _nominal_resistance(nominal_resistance), _wiper_resistance(160), _i2cPort(i2cPort)
+	AD5243(long nominal_resistance, TwoWire& i2cPort = Wire, uint8_t address = AD5243_I2C_ADDRESS) :
+		_nominal_resistance(nominal_resistance), _wiper_resistance(160), _i2cPort(i2cPort), _address(address)
 	{
 	}
 
-	AD5243(long nominal_resistance, long wiper_resistance, TwoWire& i2cPort = Wire) : _nominal_resistance(nominal_resistance), _wiper_resistance(wiper_resistance), _i2cPort(i2cPort)
+	AD5243(long nominal_resistance, long wiper_resistance, TwoWire& i2cPort = Wire, uint8_t address = AD5243_I2C_ADDRESS) :
+		_nominal_resistance(nominal_resistance), _wiper_resistance(wiper_resistance), _i2cPort(i2cPort), _address(address)
 	{
 	}
 
-	bool begin(uint8_t address = AD5243_I2C_ADDRESS)
+	AD5243(long nominal_resistance, long wiper_resistance, uint8_t address) :
+		_nominal_resistance(nominal_resistance), _wiper_resistance(wiper_resistance), _i2cPort(Wire), _address(address)
+	{
+	}
+
+	bool begin()
+	{
+		return connected();
+	}
+
+	// overwrite constructor initialized I2C address.
+	bool begin(uint8_t address)
 	{
 		_address = address;
 		return connected();


### PR DESCRIPTION
Some ctor refactoring to allow setting the I2C address via ctor, in addition to keeping the `begin()` variant.